### PR TITLE
use bulk_create method to speed things up

### DIFF
--- a/kvstore/admin/forms.py
+++ b/kvstore/admin/forms.py
@@ -18,10 +18,6 @@ class UploadBulkForm(forms.Form):
         queryset=ContentType.objects.order_by("app_label", "model").all()
     )
     input = forms.CharField(widget=forms.Textarea(attrs={'rows': 10}))
-    allow_overwrite = forms.BooleanField(
-        required=True,
-        label="Allow key overwrite"
-    )
 
     def clean_input(self):
         """  Return a list of tuples instead of text """

--- a/kvstore/admin/views.py
+++ b/kvstore/admin/views.py
@@ -30,7 +30,7 @@ def upload_bulk(request):
             ctype = bulk_entry_form.cleaned_data['object']
             count = 0
             for obj_id, k, v in bulk_entry_form.cleaned_data['input']:
-                Tag.objects.update_or_create(
+                Tag.objects.get_or_create(
                     content_type=ctype,
                     object_id=obj_id,
                     key=k,
@@ -59,17 +59,19 @@ def upload_csv(request):
             ctype = upload_csv_form.cleaned_data['object']
             csv_file = upload_csv_form.cleaned_data['file']
 
-            count = 0
+            tags = []
             for line in csv_file.readlines():
-                obj_id, k, v = line.decode('utf-8').strip().split(',')
-                Tag.objects.update_or_create(
+                obj_id, k, v = line.decode("utf-8").strip().split(",")
+                new_tag = Tag(
                     content_type=ctype,
                     object_id=obj_id.strip(),
                     key=k.strip(),
-                    defaults={'value': v.strip()}
+                    value=v.strip(),
                 )
-                count += 1
-            messages.info(request, "%s tags set" % count)
+                tags.append(new_tag)
+
+            Tag.objects.bulk_create(tags)
+            messages.info(request, "%s tags set" % len(tags))
     else:
         upload_csv_form = UploadCSVForm()
 


### PR DESCRIPTION
**What's this do?**

The `upload_csv` form was failing when we tried to update too many records. This was because we were hitting the database each time to `update_or_create`. Reverted to the previous functionality where we do not overwrite existing entries and now we create objects and do a `bulk_create()`

Checked with Gozde and the previous implementation was fine.

```console
gozde [5:46 PM]
I don't see any use of updating values for same object, object_id & key
I could use some delete function but this will be a future implementation :pray::skin-tone-2:
```

**Why are we doing this? (w/ JIRA link if applicable)**

https://infoscout.atlassian.net/browse/CA-8324

**How should this be tested?**

As the Django form submits a request containing both JSON and multipart information, I decided to test using client.post (integration test) versus unit testing the views.

**Are there any migrations? Post the sqlmigrate output**

No.

**Dependencies for merging? Releasing to production?**

Once this is merged and tagged, we will need to update the main repo to use the updated kvstore package.